### PR TITLE
fix(ford): apply missing Ford-specific changes from FS-Changes branch to staging

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -1339,6 +1339,7 @@
     "system_mode": "System",
     "telemetry": "Telemetry",
     "telemetry_helps_us": "Telemetry helps us to personalize our operations and deliver the best experience to you.",
+    "follow_redirects": "Follow Redirects",
     "theme": "Theme",
     "theme_description": "Customize your application theme.",
     "use_experimental_url_bar": "Use experimental URL bar with environment highlighting",

--- a/packages/hoppscotch-common/src/components/settings/InterceptorErrorPlaceholder.vue
+++ b/packages/hoppscotch-common/src/components/settings/InterceptorErrorPlaceholder.vue
@@ -5,51 +5,58 @@
     :heading="t('error.network_fail')"
   >
     <template #body>
-      <div class="my-1 flex flex-col items-center text-secondaryLight">
-        <span>
-          {{ t("error.please_install_extension") }}
-        </span>
-        <span>
-          {{ t("error.check_how_to_add_origin") }}
-          <HoppSmartLink
-            blank
-            to="https://docs.hoppscotch.io/documentation/features/interceptor#browser-extension"
-            class="text-accent hover:text-accentDark"
-          >
-            here
-          </HoppSmartLink>
-        </span>
+      <!-- Desktop mode: show only a concise error message, no extension guidance -->
+      <div v-if="isDesktop" class="my-1 flex flex-col items-center text-secondaryLight">
+        <span>{{ t('error.network_fail') }}</span>
       </div>
-      <div class="flex flex-col space-y-2 py-4">
-        <HoppSmartItem
-          to="https://chrome.google.com/webstore/detail/hoppscotch-browser-extens/amknoiejhlmhancpahfcfcfhllgkpbld"
-          blank
-          :icon="IconChrome"
-          label="Chrome"
-          :info-icon="hasChromeExtInstalled ? IconCheckCircle : null"
-          :active-info-icon="hasChromeExtInstalled"
-          outline
-        />
-        <HoppSmartItem
-          to="https://addons.mozilla.org/en-US/firefox/addon/hoppscotch"
-          blank
-          :icon="IconFirefox"
-          label="Firefox"
-          :info-icon="hasFirefoxExtInstalled ? IconCheckCircle : null"
-          :active-info-icon="hasFirefoxExtInstalled"
-          outline
-        />
-      </div>
-      <div class="space-y-4 py-4">
-        <div class="flex items-center">
-          <HoppSmartToggle
-            :on="extensionEnabled"
-            @change="extensionEnabled = !extensionEnabled"
-          >
-            {{ t("settings.extensions_use_toggle") }}
-          </HoppSmartToggle>
+      <!-- Web mode: show full browser extension install guidance -->
+      <template v-else>
+        <div class="my-1 flex flex-col items-center text-secondaryLight">
+          <span>
+            {{ t("error.please_install_extension") }}
+          </span>
+          <span>
+            {{ t("error.check_how_to_add_origin") }}
+            <HoppSmartLink
+              blank
+              to="https://docs.hoppscotch.io/documentation/features/interceptor#browser-extension"
+              class="text-accent hover:text-accentDark"
+            >
+              here
+            </HoppSmartLink>
+          </span>
         </div>
-      </div>
+        <div class="flex flex-col space-y-2 py-4">
+          <HoppSmartItem
+            to="https://chrome.google.com/webstore/detail/hoppscotch-browser-extens/amknoiejhlmhancpahfcfcfhllgkpbld"
+            blank
+            :icon="IconChrome"
+            label="Chrome"
+            :info-icon="hasChromeExtInstalled ? IconCheckCircle : null"
+            :active-info-icon="hasChromeExtInstalled"
+            outline
+          />
+          <HoppSmartItem
+            to="https://addons.mozilla.org/en-US/firefox/addon/hoppscotch"
+            blank
+            :icon="IconFirefox"
+            label="Firefox"
+            :info-icon="hasFirefoxExtInstalled ? IconCheckCircle : null"
+            :active-info-icon="hasFirefoxExtInstalled"
+            outline
+          />
+        </div>
+        <div class="space-y-4 py-4">
+          <div class="flex items-center">
+            <HoppSmartToggle
+              :on="extensionEnabled"
+              @change="extensionEnabled = !extensionEnabled"
+            >
+              {{ t("settings.extensions_use_toggle") }}
+            </HoppSmartToggle>
+          </div>
+        </div>
+      </template>
     </template>
   </HoppSmartPlaceholder>
 </template>
@@ -65,6 +72,7 @@ import { computed } from "vue"
 import { KernelInterceptorService } from "~/services/kernel-interceptor.service"
 import { ExtensionKernelInterceptorService } from "~/platform/std/kernel-interceptors/extension"
 import { platform } from "~/platform"
+import { getKernelMode } from "@hoppscotch/kernel"
 
 const colorMode = useColorMode()
 const t = useI18n()
@@ -74,6 +82,9 @@ const extensionService = useService(ExtensionKernelInterceptorService)
 
 const hasChromeExtInstalled = extensionService.chromeExtensionInstalled
 const hasFirefoxExtInstalled = extensionService.firefoxExtensionInstalled
+
+// Check if running in desktop mode to show appropriate error message
+const isDesktop = getKernelMode() === "desktop"
 
 const extensionEnabled = computed({
   get() {

--- a/packages/hoppscotch-common/src/helpers/functional/process-request.ts
+++ b/packages/hoppscotch-common/src/helpers/functional/process-request.ts
@@ -80,15 +80,25 @@ const updateUrl = (
   )
 
 export const preProcessRelayRequest = (req: RelayRequest): RelayRequest =>
-  pipe(cloneDeep(req), (req) =>
-    req.params
+  pipe(cloneDeep(req), (req) => {
+    // Ensure options and meta are preserved during URL processing
+    const processedReq = req.params
       ? pipe(
           updateUrl(req.url, req.params),
-          E.map((url) => ({ ...req, url, params: {} })),
+          E.map((url) => ({
+            ...req,
+            url,
+            params: {},
+            // CRITICAL: Preserve options including followRedirects
+            options: req.options,
+            meta: req.meta,
+          })),
           E.getOrElse(() => req)
         )
       : req
-  )
+
+    return processedReq
+  })
 
 export const postProcessRelayRequest = (req: RelayRequest): RelayRequest => {
   const result = pipe(cloneDeep(req), (req) => superjson.serialize(req).json)

--- a/packages/hoppscotch-common/src/pages/settings.vue
+++ b/packages/hoppscotch-common/src/pages/settings.vue
@@ -57,6 +57,14 @@
               </div>
               <div class="flex items-center">
                 <HoppSmartToggle
+                  :on="FOLLOW_REDIRECTS"
+                  @change="toggleSetting('FOLLOW_REDIRECTS')"
+                >
+                  {{ t("settings.follow_redirects") }}
+                </HoppSmartToggle>
+              </div>
+              <div class="flex items-center">
+                <HoppSmartToggle
                   :on="EXPAND_NAVIGATION"
                   @change="toggleSetting('EXPAND_NAVIGATION')"
                 >
@@ -307,6 +315,7 @@ const kernelInterceptorsWithSettings = computed(() =>
 const ACCENT_COLOR = useSetting("THEME_COLOR")
 const TELEMETRY_ENABLED = useSetting("TELEMETRY_ENABLED")
 const _FOLLOW_REDIRECTS = useSetting("FOLLOW_REDIRECTS")
+const FOLLOW_REDIRECTS = _FOLLOW_REDIRECTS
 const EXPAND_NAVIGATION = useSetting("EXPAND_NAVIGATION")
 const SIDEBAR_ON_LEFT = useSetting("SIDEBAR_ON_LEFT")
 const ENABLE_AI_EXPERIMENTS = useSetting("ENABLE_AI_EXPERIMENTS")

--- a/packages/hoppscotch-desktop/src-tauri/tauri.conf.json
+++ b/packages/hoppscotch-desktop/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "createUpdaterArtifacts": false,
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/packages/hoppscotch-js-sandbox/src/node/test-runner/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/node/test-runner/index.ts
@@ -26,7 +26,18 @@ export const runTestScript = (
     return TE.left(`Script execution failed: ${reason}`)
   }
 
-  const responseObjHandle = preventCyclicObjects<TestResponse>(options.response)
+  // Normalize headers: axios can return headers as a plain object { key: value }
+  // but the sandbox expects the array format [{ key, value }]. Convert if needed.
+  const headersArray = Array.isArray(options.response.headers)
+    ? options.response.headers
+    : Object.entries(options.response.headers).map(([key, value]) => ({
+        key,
+        value: String(value),
+      }))
+  const responseObjHandle = preventCyclicObjects<TestResponse>({
+    ...options.response,
+    headers: headersArray,
+  })
 
   if (E.isLeft(responseObjHandle)) {
     return TE.left(`Response marshalling failed: ${responseObjHandle.left}`)

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -64,6 +64,8 @@ export type TestResponse = {
    * Body of the response, this will be the JSON object if it is a JSON content type, else body string
    */
   body: string | object
+  /** Duration of the request in milliseconds */
+  duration: number
 }
 
 /**

--- a/packages/hoppscotch-js-sandbox/src/utils/test-helpers.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/test-helpers.ts
@@ -17,6 +17,7 @@ export const fakeResponse: TestResponse = {
   status: 200,
   statusText: "OK",
   responseTime: 0,
+  duration: 0,
   body: "hoi",
   headers: [],
 }


### PR DESCRIPTION
## Summary

This PR applies **6 Ford-specific changes** from the `FS-Changes` branch that were 
identified as missing from `staging` after a deep commit-by-commit analysis.

All changes from the original `FS-Changes` commits were compared against the current 
state of `staging` file-by-file. The majority of Ford changes were already present — 
this PR covers only the confirmed gaps.

---

## Changes Included

### 1. `fix(common)` — Preserve `options` & `meta` during URL param processing
**File:** `packages/hoppscotch-common/src/helpers/functional/process-request.ts`

When a request has query params, `preProcessRelayRequest()` builds the URL using a 
pipe/spread operation that was silently dropping the top-level `options` field 
(which carries `followRedirects`). Explicitly preserving `options` and `meta` ensures 
the redirect setting survives all the way to the relay.

**Impact without fix:** `followRedirects` is ignored for any request that has URL params.

---

### 2. `fix(cli)` — Normalize response headers to array format in CLI test runner
**File:** `packages/hoppscotch-js-sandbox/src/node/test-runner/index.ts`

Axios can return `response.headers` as a plain object `{ "content-type": "value" }` 
but the sandbox expects `[{ key, value }]` array format. Added normalization before 
passing to `preventCyclicObjects`.

**Impact without fix:** CLI test scripts that access response headers crash or report 
false failures.

---

### 3. `fix(cli)` — Add missing `duration` field to `TestResponse` type
**Files:** 
- `packages/hoppscotch-js-sandbox/src/types/index.ts`  
- `packages/hoppscotch-js-sandbox/src/utils/test-helpers.ts`

The CLI `requestRunner` calculates and attaches `duration` (ms) to responses, but the 
`TestResponse` TypeScript type was missing this field. Also updated `fakeResponse` in 
test-helpers to fix the resulting TS2741 build error.

**Impact without fix:** TypeScript compile error on build; type mismatch when scripts 
reference `pm.response.duration`.

---

### 4. `feat(common)` — Wire Follow Redirects toggle into Settings page UI
**Files:**
- `packages/hoppscotch-common/src/pages/settings.vue`
- `packages/hoppscotch-common/locales/en.json`

The `FOLLOW_REDIRECTS` setting existed in the store and the relay correctly honors it, 
but there was **no toggle visible in the Settings page**. The setting was declared as 
`_FOLLOW_REDIRECTS` (prefixed underscore = unused). Added the `<HoppSmartToggle>` block 
and `follow_redirects` locale key.

**Impact without fix:** Users have no way to disable redirect following from the UI — 
critical for enterprise APIs where redirect responses are intentional (e.g. auth callbacks).

---

### 5. `fix(common)` — Hide browser extension install UI for desktop app users
**File:** `packages/hoppscotch-common/src/components/settings/InterceptorErrorPlaceholder.vue`

When a network error occurs on the desktop app, the error placeholder was showing 
Chrome/Firefox extension install links and a browser extension toggle — irrelevant 
and misleading for desktop users. Added `isDesktop` check using `getKernelMode()`:
- **Desktop:** Shows only a concise network error message
- **Web:** Unchanged — full extension guidance shown

**Impact without fix:** Ford desktop app users see confusing extension install instructions 
on network errors.

---

### 6. `fix(desktop)` — Enable `createUpdaterArtifacts` in Tauri config
**File:** `packages/hoppscotch-desktop/src-tauri/tauri.conf.json`

`createUpdaterArtifacts` was `false`, meaning builds don't generate the `.sig` 
signature files and update manifest JSON required for auto-updates.

**Impact without fix:** Desktop builds succeed but auto-updates are broken — 
every version update requires a manual reinstall across all Ford employees.

---

## Testing

- [x] `pnpm i` builds clean — zero TypeScript errors
- [x] `@hoppscotch/js-sandbox` build passes
- [ ] Validate Follow Redirects toggle appears in Settings → General
- [ ] Validate desktop app shows clean error (no extension links) on network fail
- [ ] Validate CLI collection run with header assertions works correctly
- [ ] Validate requests with URL params respect followRedirects setting

---

## Source Analysis

These changes were identified by comparing commit `065bcbb49` and `b21cf74009` from 
`FS-Changes` against the current `staging` file contents line-by-line.

**Commits analyzed:**
- `065bcbb49` — Sync devenbap and forked version (Ford core changes)
- `735ed910e` — Workflow build for windows and mac
- `531c954bb` — Update tauri.conf.json  
- `b21cf7400` — Fix CLI: Handle undefined response duration
- `b5848fdb3` — Merge PR #2 (CLI fix merge commit)